### PR TITLE
ChatSpace メッセージ投稿の非同期通信機能の実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ gem 'coffee-rails', '~> 4.2'
 # Use jquery as the JavaScript library
 gem 'jquery-rails'
 # Turbolinks makes navigating your web application faster. Read more: https://github.com/turbolinks/turbolinks
-gem 'turbolinks', '~> 5'
+# gem 'turbolinks', '~> 5'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem 'jbuilder', '~> 2.5'
 # Use Redis adapter to run Action Cable in production

--- a/Gemfile
+++ b/Gemfile
@@ -38,6 +38,7 @@ gem 'jbuilder', '~> 2.5'
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platform: :mri
+  gem "pry-rails"
   gem 'rspec-rails', '~> 3.5'
   gem 'factory_bot_rails'
   gem 'rails-controller-testing'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -218,9 +218,6 @@ GEM
     thor (0.20.3)
     thread_safe (0.3.6)
     tilt (2.0.10)
-    turbolinks (5.2.1)
-      turbolinks-source (~> 5.2)
-    turbolinks-source (5.2.0)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
     uglifier (4.2.0)
@@ -261,7 +258,6 @@ DEPENDENCIES
   sass-rails (~> 5.0)
   spring
   spring-watcher-listen (~> 2.0.0)
-  turbolinks (~> 5)
   tzinfo-data
   uglifier (>= 1.3.0)
   web-console (>= 3.3.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -52,6 +52,7 @@ GEM
       image_processing (~> 1.1)
       mimemagic (>= 0.3.0)
       mini_mime (>= 0.1.3)
+    coderay (1.1.2)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0)
@@ -126,6 +127,11 @@ GEM
     nokogiri (1.10.7)
       mini_portile2 (~> 2.4.0)
     orm_adapter (0.5.0)
+    pry (0.12.2)
+      coderay (~> 1.1.0)
+      method_source (~> 0.9.0)
+    pry-rails (0.3.9)
+      pry (>= 0.10.4)
     public_suffix (4.0.1)
     puma (3.12.2)
     rack (2.0.7)
@@ -250,6 +256,7 @@ DEPENDENCIES
   listen (~> 3.0.5)
   mini_magick
   mysql2 (>= 0.3.18, < 0.6.0)
+  pry-rails
   puma (~> 3.12)
   rails (~> 5.0.7, >= 5.0.7.2)
   rails-controller-testing

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -12,5 +12,4 @@
 //
 //= require jquery
 //= require jquery_ujs
-//= require turbolinks
 //= require_tree .

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -49,9 +49,9 @@ $(function(){
       // 通信失敗時の処理
       alert('ファイルの取得に失敗しました。');
     })
-    .always(() => {
+    .always(function () {
       // submitボタンを有効化する
       $(".submit-btn").removeAttr("disabled");
-    })
+    });
   })
 });

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -48,11 +48,10 @@ $(function(){
       alert('ファイルの取得に失敗しました。');
     })
     .always(function () {
-      // テキストボックスの内容をクリアする
-      $('#message_body').val('');
-      $('#message_image').val('');
+      // メッセージテキスト、画像テキストの内容をクリアする
+      $('#new_message')[0].reset();
       // submitボタンを有効化する
-      $(".submit-btn").removeAttr("disabled");
+      $('.submit-btn').removeAttr('disabled');
     });
   })
 });

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,0 +1,7 @@
+$(function(){
+
+  $('#new_message').on('submit', function(e){
+    e.preventDefault()
+    console.log('イベント発火');
+  })
+});

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -42,14 +42,15 @@ $(function(){
       // 通信成功時の処理
       var html = buildHTML(message);
       $('.messages').append(html).animate({ scrollTop: $('.messages')[0].scrollHeight});
-      $('#message_body').val('');
-      $('#message_image').val('');
     })
     .fail(function () {
       // 通信失敗時の処理
       alert('ファイルの取得に失敗しました。');
     })
     .always(function () {
+      // テキストボックスの内容をクリアする
+      $('#message_body').val('');
+      $('#message_image').val('');
       // submitボタンを有効化する
       $(".submit-btn").removeAttr("disabled");
     });

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -2,6 +2,15 @@ $(function(){
 
   $('#new_message').on('submit', function(e){
     e.preventDefault()
-    console.log('イベント発火');
+    var formData = new FormData(this);
+    var url = $(this).attr('action');
+    $.ajax({
+      url: url,       //同期通信でいう『パス』
+      type: 'POST',   //同期通信でいう『HTTPメソッド』
+      data: formData, //取得したFormData  
+      dataType: 'json',
+      processData: false,
+      contentType: false
+    })
   })
 });

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,5 +1,31 @@
 $(function(){
 
+  function buildHTML(message){
+    // 「もしメッセージに画像が含まれていたら」という条件式
+    if (message.image.url != null) {
+      //メッセージに画像が含まれる場合のHTMLを作る
+      var html = `<div class="message">
+                    <div class="message__upper-info">
+                      <p class="message__upper-info__talker">${message.name}</p>
+                      <p class="message__upper-info__date">${message.created_at}</p>
+                    </div>
+                    <p class="message__text">${message.body}
+                    <img class="lower-message__image" src="${message.image.url}" alt="${message.imagename}">
+                    </p>
+                  </div>`
+    } else {
+      //メッセージに画像が含まれない場合のHTMLを作る
+      var html = `<div class="message">
+                    <div class="message__upper-info">
+                      <p class="message__upper-info__talker">${message.name}</p>
+                      <p class="message__upper-info__date">${message.created_at}</p>
+                    </div>
+                    <p class="message__text">${message.body}</p>
+                  </div>`
+    }
+    return html
+  }
+
   $('#new_message').on('submit', function(e){
     e.preventDefault()
     var formData = new FormData(this);
@@ -11,6 +37,21 @@ $(function(){
       dataType: 'json',
       processData: false,
       contentType: false
+    })
+    .done(function(message){
+      // 通信成功時の処理
+      var html = buildHTML(message);
+      $('.messages').append(html).animate({ scrollTop: $('.messages')[0].scrollHeight});
+      $('#message_body').val('');
+      $('#message_image').val('');
+    })
+    .fail(function () {
+      // 通信失敗時の処理
+      alert('ファイルの取得に失敗しました。');
+    })
+    .always(() => {
+      // submitボタンを有効化する
+      $(".submit-btn").removeAttr("disabled");
     })
   })
 });

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -44,7 +44,7 @@ $(function(){
       var html = buildHTML(message);
       // 生成したhtmlをmessages要素の最後に追加して、
       // 一番下にスクロールする。
-      $('.messages').append(html).animate({ scrollTop: $('.messages')[0].scrollHeight});
+      $('.messages').append(html).animate({scrollTop: $('.messages')[0].scrollHeight});
     })
     .fail(function () {
       // 通信失敗時の処理

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -40,7 +40,10 @@ $(function(){
     })
     .done(function(message){
       // 通信成功時の処理
+      // 投稿されたメッセージをjsonからhtmlに生成する。
       var html = buildHTML(message);
+      // 生成したhtmlをmessages要素の最後に追加して、
+      // 一番下にスクロールする。
       $('.messages').append(html).animate({ scrollTop: $('.messages')[0].scrollHeight});
     })
     .fail(function () {
@@ -48,9 +51,9 @@ $(function(){
       alert('ファイルの取得に失敗しました。');
     })
     .always(function () {
-      // メッセージテキスト、画像テキストの内容をクリアする
+      // メッセージテキスト、画像テキストの内容をクリアする。
       $('#new_message')[0].reset();
-      // submitボタンを有効化する
+      // submitボタンを有効化する。
       $('.submit-btn').removeAttr('disabled');
     });
   })

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -14,7 +14,6 @@ class MessagesController < ApplicationController
         format.json
       end
     else
-      # binding.pry
       @messages = @group.messages.includes(:user)
       flash.now[:alert] = "メッセージを入力してください。"
       render :index

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -9,10 +9,13 @@ class MessagesController < ApplicationController
   def create
     @message = @group.messages.new(message_params)
     if @message.save
-      redirect_to group_messages_path(@group), notice: 'メッセージが送信されました'
+      respond_to do |format|
+        format.html { redirect_to group_messages_path(@group), notice: "メッセージが送信されました" }
+        format.json
+      end
     else
       @messages = @group.messages.includes(:user)
-      flash.now[:alert] = 'メッセージを入力してください。'
+      flash.now[:alert] = "メッセージを入力してください。"
       render :index
     end
   end

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -14,6 +14,7 @@ class MessagesController < ApplicationController
         format.json
       end
     else
+      # binding.pry
       @messages = @group.messages.includes(:user)
       flash.now[:alert] = "メッセージを入力してください。"
       render :index

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -4,8 +4,6 @@
     %meta{:content => "text/html; charset=UTF-8", "http-equiv" => "Content-Type"}/
     %title ChatSpace
     = csrf_meta_tags
-    -# = stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload'
-    -# = javascript_include_tag 'application', 'data-turbolinks-track': 'reload'
     = stylesheet_link_tag    'application', media: 'all'
     = javascript_include_tag 'application'
   %body

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -4,8 +4,8 @@
     %meta{:content => "text/html; charset=UTF-8", "http-equiv" => "Content-Type"}/
     %title ChatSpace
     = csrf_meta_tags
-    = stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload'
-    = javascript_include_tag 'application', 'data-turbolinks-track': 'reload'
+    -# = stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload'
+    -# = javascript_include_tag 'application', 'data-turbolinks-track': 'reload'
   %body
     = render 'layouts/notifications'
     = yield

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -6,6 +6,8 @@
     = csrf_meta_tags
     -# = stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload'
     -# = javascript_include_tag 'application', 'data-turbolinks-track': 'reload'
+    = stylesheet_link_tag    'application', media: 'all'
+    = javascript_include_tag 'application'
   %body
     = render 'layouts/notifications'
     = yield

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,9 +1,7 @@
 json.id @message.id
 json.body @message.body
 json.image @message.image
-if @message.image.nil?
-  json.imagename File.basename(@message.image, ".*")
-end
+json.imagename File.basename(@message.image, ".*") if @message.image.nil?
 json.user_id @message.user_id
 json.group_id @message.group_id
 json.name @message.user.name

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -2,7 +2,5 @@ json.id @message.id
 json.body @message.body
 json.image @message.image
 json.imagename File.basename(@message.image, ".*") if @message.image.nil?
-json.user_id @message.user_id
-json.group_id @message.group_id
 json.name @message.user.name
 json.created_at @message.created_at.strftime('%Y/%m/%d %H:%M:%S')

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,0 +1,10 @@
+json.id @message.id
+json.body @message.body
+json.image @message.image
+if @message.image.nil?
+  json.imagename File.basename(@message.image, ".*")
+end
+json.user_id @message.user_id
+json.group_id @message.group_id
+json.name @message.user.name
+json.created_at @message.created_at.strftime('%Y/%m/%d %H:%M:%S')


### PR DESCRIPTION
## What
JSON APIの作成する
非同期通信機能を実装する
・1 jsファイルを作成する
・2 フォームが送信されたら、イベントが発火するようにする
・3 2のイベントが発火したときにAjaxを使用して、messages#createが動くようにする
・4 messages#createでメッセージを保存し、respond_toを使用してHTMLとJSONの場合で処理を分ける
・5 jbuilderを使用して、作成したメッセージをJSON形式で返す
・6 返ってきたJSONをdoneメソッドで受取り、HTMLを作成する
・7 6で作成したHTMLをメッセージ画面の一番下に追加する
・8 メッセージを送信したとき、メッセージ画面を最下部にスクロールする
・9 連続で送信ボタンを押せるようにする
・10 非同期に失敗した場合の処理も準備する

## Why
ChatSpaceのメッセージ投稿に非同期機能を搭載することで、
リダイレクトによる画面の再描画の回数を低減させ、利便性が向上する。
ただし、メッセージを未入力で送信すると、フラッシュメッセージが表示できない。